### PR TITLE
Update gng.rb

### DIFF
--- a/Formula/gng.rb
+++ b/Formula/gng.rb
@@ -5,8 +5,6 @@ class Gng < Formula
   sha256 "2ae84cedf372e50beea12f5ef13ee58892c87b0bea379709e34b01df6b5a255c"
   license "Apache-2.0"
 
-  bottle :unneeded
-
   conflicts_with "gdub",
     because: "GNG is the accessor of `gdub`, Please visit https://gng.dsun.org for details"
 


### PR DESCRIPTION
Removing that line can fix an issue that is being shown when `brew` is executed:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the gdubw/gng tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/gdubw/homebrew-gng/Formula/gng.rb:8
```

It is related to this issue: https://github.com/gdubw/gng/issues/25

Also this one: https://github.com/gdubw/homebrew-gng/issues/2
